### PR TITLE
add a bft test without propose 

### DIFF
--- a/bft/Cargo.toml
+++ b/bft/Cargo.toml
@@ -22,6 +22,7 @@ log = "=0.4.3"
 logger = { git = "https://github.com/cryptape/cita-common.git", branch = "develop" }
 protobuf = { version = "2.0.2", features = ["with-bytes"]}
 ethereum-types = "0.3.2"
+rand = "0.6.1"
 
 [build-dependencies]
 util = { git = "https://github.com/cryptape/cita-common.git", branch = "develop" }

--- a/bft/src/algorithm.rs
+++ b/bft/src/algorithm.rs
@@ -117,7 +117,7 @@ impl Bft {
             timer_notity: rs,
 
             params,
-            height: 0,
+            height: INIT_HEIGHT,
             round: INIT_ROUND,
             step: Step::default(),
             votes: VoteCollector::new(),

--- a/bft/src/algorithm.rs
+++ b/bft/src/algorithm.rs
@@ -92,7 +92,7 @@ pub struct Bft {
     pub height: usize,
     pub round: usize,
     pub step: Step,
-    votes: VoteCollector,
+    pub votes: VoteCollector,
     proposals: ProposalCollector,
     proposal: Option<H256>,
     lock_round: Option<usize>,
@@ -239,8 +239,9 @@ impl Bft {
                 "add proposal height {} round {}",
                 proposal_height, proposal_round
             );
-            
-            self.proposals.add(proposal_height, proposal_height, proposal);
+
+            self.proposals
+                .add(proposal_height, proposal_height, proposal);
             return Ok((proposal_height, proposal_round));
         }
         Err(EngineError::UnexpectedMessage)
@@ -269,7 +270,7 @@ impl Bft {
             self.proposal = Some(self.lock_proposal.clone().unwrap().crypt_hash());
         } else {
             // use the new proposal and lock it
-            self.proposal = Some(proposal.block.crypt_hash());
+            self.proposal = Some(proposal.crypt_hash());
             self.lock_proposal = Some(proposal);
             debug!(
                 "save the proposal's hash: height {:?}, round {}, proposal {:?}",

--- a/bft/src/message.rs
+++ b/bft/src/message.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use bft::Step;
+use algorithm::Step;
 use ethereum_types::H256;
 use voteset::{Proposal, ProposalwithProof, SignProposal};
 

--- a/bft/src/timer.rs
+++ b/bft/src/timer.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::sync::mpsc::{Receiver, Sender};
 use std::time::{Duration, Instant};
 
-use bft::Step;
+use algorithm::Step;
 
 #[derive(Debug, Clone)]
 pub struct TimeoutInfo {

--- a/bft/src/voteset.rs
+++ b/bft/src/voteset.rs
@@ -14,7 +14,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-use bft::Step;
+use algorithm::Step;
 use bincode::{deserialize, serialize, Infinite};
 use crypto::{pubkey_to_address, Sign, Signature};
 use crypto_hash::{digest, Algorithm};
@@ -264,8 +264,6 @@ impl ProposalRoundCollector {
 #[derive(Clone, Debug, Default)]
 pub struct Proposal {
     pub block: Vec<u8>,
-    pub height: usize,
-    pub round: usize,
     pub lock_round: Option<usize>,
     pub lock_votes: Option<VoteSet>,
 }
@@ -274,8 +272,6 @@ impl Proposal {
     pub fn new() -> Self {
         Proposal {
             block: Vec::new(),
-            height: MAX,
-            round: MAX,
             lock_round: None,
             lock_votes: None,
         }

--- a/bft/tests/test_bft.rs
+++ b/bft/tests/test_bft.rs
@@ -1,0 +1,144 @@
+// CITA
+// Copyright 2016-2017 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+extern crate bft_rs as bft;
+extern crate cita_crypto as crypto;
+extern crate crypto_hash as hash;
+extern crate ethereum_types;
+extern crate rand;
+
+use bft::algorithm::{Bft, Step};
+use bft::message::{CommitMessage, Message, ProposalMessage};
+use bft::params::{BftParams, BftTimer};
+use bft::voteset::*;
+use bft::CryptHash;
+use crypto::{pubkey_to_address, CreateKey, KeyPair, PubKey, Signature, Signer};
+use ethereum_types::{Address, H256};
+use hash::{digest, Algorithm};
+use rand::{random, thread_rng, Rng};
+
+use std::sync::mpsc::channel;
+use std::usize::MAX;
+use std::vec::Vec;
+
+struct NodeInfo {
+    keypair: KeyPair,
+    address: Address,
+}
+
+fn gen_info() -> NodeInfo {
+    let keypair = KeyPair::gen_keypair();
+    let pubkey = *keypair.pubkey();
+    let address = pubkey_to_address(&pubkey);
+    NodeInfo {
+        keypair: keypair,
+        address: address,
+    }
+}
+
+fn create_auth() -> (AuthorityManage, Vec<NodeInfo>) {
+    let info_1 = gen_info();
+    let info_2 = gen_info();
+    let info_3 = gen_info();
+    let proposers = vec![info_1.address, info_2.address, info_3.address];
+    let validators = proposers.clone();
+    let mut info = vec![info_1, info_2, info_3];
+    let auth = AuthorityManage {
+        proposers: proposers,
+        validators: validators,
+        proposers_old: Vec::new(),
+        validators_old: Vec::new(),
+        height_old: MAX,
+    };
+    (auth, info)
+}
+
+fn generate_proposal() -> Proposal {
+    let mut block = vec![1, 2, 3, 4];
+    // make faster by caching thread_rng
+    let mut rng = thread_rng();
+    for x in block.iter_mut() {
+        *x = rng.gen();
+    }
+    Proposal {
+        block: block,
+        lock_round: None,
+        lock_votes: None,
+    }
+}
+
+fn generate_message(
+    engine: Bft,
+    auth: AuthorityManage,
+    infos: Vec<NodeInfo>,
+    p: Proposal,
+    s: Step,
+    h: usize,
+    r: usize,
+) {
+    let mut byzantine = p.block.clone();
+    let mut rng = thread_rng();
+
+    for x in byzantine.iter_mut() {
+        *x = rng.gen();
+    }
+
+    let byzantine_node = infos[2].address;
+    for ii in infos.iter() {
+        if ii.address != byzantine_node {
+            engine.votes.add(
+                h,
+                r,
+                s,
+                ii.address,
+                &VoteMessage {
+                    proposal: Some(H256::from(digest(Algorithm::SHA256, &p.block).as_slice())),
+                    signature: Signature::default(),
+                },
+            );
+        } else {
+            engine.votes.add(
+                h,
+                r,
+                s,
+                ii.address,
+                &VoteMessage {
+                    proposal: Some(H256::from(digest(Algorithm::SHA256, &byzantine).as_slice())),
+                    signature: Signature::default(),
+                },
+            );
+        }
+    }
+}
+
+#[test]
+fn test_bft_without_nil() {
+    let key_pair = KeyPair::gen_keypair();
+    let pub_key = *key_pair.pubkey();
+    let address = pubkey_to_address(&pub_key);
+    let params = BftParams {
+        timer: BftTimer::default(),
+        signer: Signer {
+            keypair: key_pair,
+            address: address,
+        },
+    };
+    let (authority_list, info) = create_auth();
+    let (main_to_timer, timer_from_main) = channel();
+    let (timer_to_main, main_from_timer) = channel();
+    let mut engine = Bft::new(main_to_timer, main_from_timer, params, authority_list);
+}

--- a/bft/tests/test_bft.rs
+++ b/bft/tests/test_bft.rs
@@ -159,6 +159,12 @@ fn test_bft_without_propose() {
 
         // step proposal
         let proposal = generate_proposal();
+        println!(
+            "the proposal is {:?}, height{}, round{}.",
+            proposal.block.clone(),
+            height,
+            round
+        );
         proposals.push(proposal.block.clone());
 
         // step proposal wait
@@ -196,7 +202,13 @@ fn test_bft_without_propose() {
 
         // step precommit wait
         let commit = engine.proc_commit(height, round);
-        consensus_results.push(commit.unwrap().proposal.block);
+        consensus_results.push(commit.clone().unwrap().proposal.block);
+        println!(
+            "the consensus is {:?}, height{}, round{}",
+            commit.clone().unwrap().proposal.block,
+            height,
+            round
+        );
         // write to log
 
         engine.change_step(height, round, Step::Commit, true);


### PR DESCRIPTION
Do test for the bft state machine with a single thread. Simulate four nodes which include one byzantine node, and the test node do not need to give a proposal.