### PR TITLE
refactor: change signature of check_proof

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,13 +472,16 @@ pub trait BftSupport: Sync + Send {
 /// A public function for proof validation.
 /// The input [`height`] is the height of block involving the proof.
 /// The input [`authorities`] is the authority_list for the proof.
-/// The fn [`crypt_hash`], [`check_sig`], [`hash`] are user-defined.
+/// The fn [`crypt_hash`], [`check_sig`] are user-defined.
+/// signature of the functions:
+/// - [`crypt_hash`]: `fn(msg: &[u8]) -> Vec<u8>`
+/// - [`check_sig`]:  `fn(signature: &[u8], hash: &[u8]) -> Option<Address>`
 pub fn check_proof(
     proof: &Proof,
     height: u64,
     authorities: &[Node],
-    crypt_hash: fn(msg: &[u8]) -> Vec<u8>,
-    check_sig: fn(signature: &[u8], hash: &[u8]) -> Option<Address>,
+    crypt_hash: impl Fn(&[u8]) -> Vec<u8>,
+    check_sig: impl Fn(&[u8], &[u8]) -> Option<Address>,
 ) -> bool {
     if proof.height == 0 {
         return true;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -402,7 +402,7 @@ where
                 return Err(BftError::CheckBlockFailed);
             }
 
-            let mut function = self.function.clone();
+            let function = self.function.clone();
             let sender = self.msg_sender.clone();
             cross_thread::scope(|s| {
                 s.spawn(move |_| {


### PR DESCRIPTION
change sigature to enable use closure which captures variables as parameter.
ref: <https://stackoverflow.com/questions/36390665/in-rust-how-do-you-pass-a-function-as-a-parameter>